### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ Cargo.lock
 **/*.rs.bk
 
 # Don't add the generated MDBook artifacts
-docs/book/
+book/


### PR DESCRIPTION
Ignores `book/` instead of `docs/book`, which was copy-pasted from the Sway repo.