### PR TITLE
Rename summary heading.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# Fuel Docs
+# Summary
 
 - [Developer Quickstart]()
 


### PR DESCRIPTION
The summary heading isn't actually used, but by convention it's just called "Summary"