### PR TITLE
Issue#39 update directory structure references in developer quickstart

### DIFF
--- a/src/developer-quickstart.md
+++ b/src/developer-quickstart.md
@@ -80,12 +80,13 @@ Here is the project that `Forc` has initialized:
 ```console
 $ tree fuel-project
 fuel-project
-├── Cargo.toml
-├── Forc.toml
-├── src
-│   └── main.sw
-└── tests
-    └── harness.rs
+└── counter_contract
+    ├── Cargo.toml
+    ├── Forc.toml
+    ├── src
+    │   └── main.sw
+    └── tests
+        └── harness.rs
 ```
 
 `Forc.toml` is the _manifest file_ (similar to `Cargo.toml` for Cargo or `package.json` for Node) and defines project metadata such as the project name and dependencies. You'll notice a `Cargo.toml` file because `forc` uses `cargo` under the hood.
@@ -325,7 +326,7 @@ $ npx create-react-app frontend --template typescript
 Success! Created frontend at Fuel/fuel-project/frontend
 ```
 
-You should now have your outer folder, `fuel-project`, with two folders inside: `front-end` and `fuel-contract`
+You should now have your outer folder, `fuel-project`, with two folders inside: `counter_contract` and `frontend`
 
 ![project folder structure](./images/quickstart-folder-structure.png)
 

--- a/src/fuelvm/memory_model.md
+++ b/src/fuelvm/memory_model.md
@@ -2,6 +2,6 @@
 
 The EVM uses a linear memory (i.e. starting at zero and growing), without a defined limit. Allocating memory costs [a quadratic amount of gas](https://github.com/ethereum/yellowpaper/blob/8fea825c80e27fa9df5d89fb3365d1067788724e/Paper.tex#L2114), which severely limits the amount of memory usable in a single context (i.e. contract call).
 
-In addition, the EVM has a separate memory space per context. Contexts may communicate with each other my copying data to call data and return data buffers.
+In addition, the EVM has a separate memory space per context. Contexts may communicate with each other by copying data to call data and returning data buffers.
 
 The FuelVM uses a single share memory block _per transaction_. Memory is allocated statically with a known upper bound, allowing for straightforward implementation of heap types such as [vectors](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/vec.sw). Memory in the FuelVM is globally readable across contexts, but locally writable. Each context may only write to portions of the stack and the heap which it has [ownership](https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md#ownership) over.

--- a/src/technology/fraud_proofs.md
+++ b/src/technology/fraud_proofs.md
@@ -1,6 +1,6 @@
 # Fraud Proofs
 
-Fraud proofs are a blockchain verification mechanism whereby a claim on a new block is accepted unless a proof the claim is invalid is provided within some configurable time window. This allows trust-minimized light clients to be secure under the assumption only a single honest full node is available in the network to produce fraud proofs. Both the Fuel protocol and the FuelVM are designed to be fraud-provable in restritive environments such as the Ethereum Virtual Machine.
+Fraud proofs are a blockchain verification mechanism whereby a claim on a new block is accepted unless a proof the claim is invalid is provided within some configurable time window. This allows trust-minimized light clients to be secure under the assumption only a single honest full node is available in the network to produce fraud proofs. Both the Fuel protocol and the FuelVM are designed to be fraud-provable in restrictive environments such as the Ethereum Virtual Machine.
 
 [State-transition fraud proofs](https://arxiv.org/abs/1809.09044) are a general-purpose fraud proof mechanism, but come with the downside of requiring a global state tree—an inherently sequential bottleneck. [UTXO fraud proofs](https://ethresear.ch/t/compact-fraud-proofs-for-utxo-chains-without-intermediate-state-serialization/5885) avoid this bottleneck; they simply require each spend of a UTXO to "point" to the creation of the UTXO. Proving the pointer is invalid, or that whatever is being pointed to doesn't match whatever is being spent, are sufficient for exhaustively proving fraud.
 


### PR DESCRIPTION
In 1.developer-quickstart; correct the dir tree and maintain same naming for folders.
In 3.2fraud proofs and 4.2memory model; minor spelling and grammar

closes #39