### PR TITLE
add link to the fuel specs

### DIFF
--- a/src/fuelvm/index.md
+++ b/src/fuelvm/index.md
@@ -3,3 +3,5 @@
 - [Contract and Call Model](./contract_call_model.md)
 - [Memory Model](./memory_model.md)
 - [Multiple Native Assets](./native_assets.md)
+
+Read the full VM spec [here](https://fuellabs.github.io/fuel-specs/master/).


### PR DESCRIPTION
Now that the fuel-specs is now a book, adding a link to it in the Fuel Book.