### PR TITLE
Update Sway Apps examples to reflect changes in repo

### DIFF
--- a/src/for-developers/example-contracts.md
+++ b/src/for-developers/example-contracts.md
@@ -2,7 +2,7 @@
 
 [sway-applications](https://github.com/FuelLabs/sway-applications) contains fullstack-applications and smart contracts built with Sway. These examples serve as building blocks for developers and demonstrate common use-cases, patterns, and functionality that can be implemented using Sway.
 
-## Example Applications:
+## Example Applications
 
 * [Airdrop](https://github.com/FuelLabs/sway-applications/blob/master/airdrop) is a token distribution program where users are able to claim tokens given a valid merkle proof.
 * [Automated Market Maker (AMM)](https://github.com/FuelLabs/sway-applications/blob/master/AMM) is a decentralized exchange protocol that manages liquidity pools supplied by its users and determines prices algorithmically while exchanging assets.

--- a/src/for-developers/example-contracts.md
+++ b/src/for-developers/example-contracts.md
@@ -19,4 +19,4 @@
 * [Oracle](https://github.com/FuelLabs/sway-applications/blob/master/oracle) is a smart contract that provides off-chain data to on-chain applications.
 * [OTC Swap Predicate](https://github.com/FuelLabs/sway-applications/blob/master/OTC-swap-predicate) is a predicate that can be used to propose and execute an atomic swap between two parties without requiring any on-chain state.
 
-> Please note that each project has a `toolchain-config.toml` file that contains all the dependencies required to run it and automatically overrides toolchain dependencies installed on your local machine. This means that you can run the project without having to manually install or update your toolchain.
+> Please note that each project has a `fuel-toolchain.toml` file that contains all the dependencies required to run it and automatically overrides toolchain dependencies installed on your local machine. This means that you can run the project without having to manually install or update your toolchain.

--- a/src/for-developers/example-contracts.md
+++ b/src/for-developers/example-contracts.md
@@ -2,6 +2,8 @@
 
 [sway-applications](https://github.com/FuelLabs/sway-applications) contains fullstack-applications and smart contracts built with Sway. These examples serve as building blocks for developers and demonstrate common use-cases, patterns, and functionality that can be implemented using Sway.
 
+> Each project above is independent of the other projects and thus every project has its own instructions and files required to run it.
+
 ## Example Applications
 
 * [Airdrop](https://github.com/FuelLabs/sway-applications/blob/master/airdrop) is a token distribution program where users are able to claim tokens given a valid merkle proof.
@@ -17,4 +19,4 @@
 * [Oracle](https://github.com/FuelLabs/sway-applications/blob/master/oracle) is a smart contract that provides off-chain data to on-chain applications.
 * [OTC Swap Predicate](https://github.com/FuelLabs/sway-applications/blob/master/OTC-swap-predicate) is a predicate that can be used to propose and execute an atomic swap between two parties without requiring any on-chain state.
 
-> Please note all projects currently use `forc 0.32.2`, `fuel-core 0.15.1`, and `rust 1.66.0`.
+> Please note that each project has a `toolchain-config.toml` file that contains all the dependencies required to run it and automatically overrides toolchain dependencies installed on your local machine. This means that you can run the project without having to manually install or update your toolchain.

--- a/src/for-developers/example-contracts.md
+++ b/src/for-developers/example-contracts.md
@@ -1,21 +1,20 @@
 # Sway Application Examples
 
-Developers are encouraged to reference the `sway-applications` repo for examples for common patterns and functionality. [This repository](https://github.com/FuelLabs/sway-applications) contains smart contracts that are written in Sway in order to demonstrate what can be built, and offer forkable code for others to build on.
+[sway-applications](https://github.com/FuelLabs/sway-applications) contains fullstack-applications and smart contracts built with Sway. These examples serve as building blocks for developers and demonstrate common use-cases, patterns, and functionality that can be implemented using Sway.
 
-We have the following contracts available as a reference:
+## Example Applications:
 
-- Airdrop is a token distribution program where users are able to claim tokens given a valid merkle proof.
-- Automated Market Maker (AMM) is a decentralized exchange protocol that manages liquidity pools supplied by its users and determines prices algorithmically while exchanging assets.
-- Decentralized Autonomous Organization (DAO) is an organization where users get to vote on governance proposals using governance tokens.
-- English Auction is an auction where users bid up the price of an asset until the bidding period has ended or a reserve has been met.
-- Escrow is a third party that keeps an asset on behalf of multiple parties.
-  Fundraiser is a program allowing users to pledge towards a goal.
-- Multi-Signature Wallet is a wallet that requires multiple signatures to execute a transaction.
-- Name-Registry allows users to perform transactions with human readable names instead of addresses.
-- Non-Fungible Token (NFT) is a token contract which provides unique collectibles, identified and differentiated by token IDs, where tokens contain metadata giving them distinctive characteristics.
-- Oracle is a smart contract that provides off-chain data to on-chain applications.
-  OTC Swap Predicate is a predicate that can be used to propose and execute an atomic swap between two parties without requiring any on-chain state.
+* [Airdrop](https://github.com/FuelLabs/sway-applications/blob/master/airdrop) is a token distribution program where users are able to claim tokens given a valid merkle proof.
+* [Automated Market Maker (AMM)](https://github.com/FuelLabs/sway-applications/blob/master/AMM) is a decentralized exchange protocol that manages liquidity pools supplied by its users and determines prices algorithmically while exchanging assets.
+* [Decentralized Autonomous Organization (DAO)](https://github.com/FuelLabs/sway-applications/blob/master/DAO) is an organization where users get to vote on governance proposals using governance tokens.
+* [English Auction](https://github.com/FuelLabs/sway-applications/blob/master/auctions/english-auction) is an auction where users bid up the price of an asset until the bidding period has ended or a reserve has been met.
+* [Escrow](https://github.com/FuelLabs/sway-applications/blob/master/escrow) is a third party that keeps an asset on behalf of multiple parties.
+* [Fundraiser](https://github.com/FuelLabs/sway-applications/blob/master/fundraiser) is a program allowing users to pledge towards a goal.
+* [Frational-NFT](https://github.com/FuelLabs/sway-applications/blob/master/fractional-NFT) allows multiple parties to claim ownership of an NFT directly proportional to the number of tokens they hold.
+* [Multi-Signature Wallet](https://github.com/FuelLabs/sway-applications/blob/master/multisig-wallet) is a wallet that requires multiple signatures to execute a transaction.
+* [Name-Registry](https://github.com/FuelLabs/sway-applications/blob/master/name-registry) allows users to perform transactions with human readable names instead of addresses.
+* [Non-Fungible Token (NFT)](https://github.com/FuelLabs/sway-applications/blob/master/NFT) is a token contract which provides unique collectibles, identified and differentiated by token IDs, where tokens contain metadata giving them distinctive characteristics.
+* [Oracle](https://github.com/FuelLabs/sway-applications/blob/master/oracle) is a smart contract that provides off-chain data to on-chain applications.
+* [OTC Swap Predicate](https://github.com/FuelLabs/sway-applications/blob/master/OTC-swap-predicate) is a predicate that can be used to propose and execute an atomic swap between two parties without requiring any on-chain state.
 
-View all of the applications [here](https://github.com/FuelLabs/sway-applications).
-
-> Please note all projects currently use forc 0.31.1, and fuel-core 0.14.1.
+> Please note all projects currently use `forc 0.32.2`, `fuel-core 0.15.1`, and `rust 1.66.0`.


### PR DESCRIPTION
Added the following changes in the Sway Applications page:
- Changed description
- Added links to individual projects
- Added new Fractional-NFT example
- Added latest versions of forc and fuel-core being used in the apps