### PR TITLE
Update «forc wallet» command

### DIFF
--- a/src/developer-quickstart.md
+++ b/src/developer-quickstart.md
@@ -324,13 +324,13 @@ The terminal will output a `message to sign` and prompt you for a signature. Ope
 Grab the `message to sign` from your other terminal and sign with your account by running the following command:
 
 ```console
-forc wallet sign` + `[message to sign, without brackets]` + `[the account number, without brackets]`
+forc wallet sign --id [message to sign, without brackets] --account-index [the account number, without brackets]
 ```
 
 Your command should look like this:
 
 ```console
-$ forc wallet sign 16d7a8f9d15cfba1bd000d3f99cd4077dfa1fce2a6de83887afc3f739d6c84df 0
+$ forc wallet sign --id 16d7a8f9d15cfba1bd000d3f99cd4077dfa1fce2a6de83887afc3f739d6c84df --account-index 0
 Please enter your password to decrypt initialized wallet's phrases:
 Signature: 736dec3e92711da9f52bed7ad4e51e3ec1c9390f4b05caf10743229295ffd5c1c08a4ca477afa85909173af3feeda7c607af5109ef6eb72b6b40b3484db2332c
 ```


### PR DESCRIPTION
It seems that the signature for "forc wallet" changed. I'm using v0.1.3.

If I run what the docs says:

```bash
forc wallet sign 16d7a8f9d15cfba1bd000d3f99cd4077dfa1fce2a6de83887afc3f739d6c84df 0
```

I get:
![image](https://user-images.githubusercontent.com/2486142/216444454-aed3c68b-e193-460d-bb26-8b3c4ad8a81e.png)

This is the right command:
```bash
forc wallet sign --id 16d7a8f9d15cfba1bd000d3f99cd4077dfa1fce2a6de83887afc3f739d6c84df --account-index 0
```

I updated it on the docs. Happy to tweak if needed.

Thanks!