### PR TITLE
Add Google Analytics ID to book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "The Fuel Book"
+google_analytics_id: "G-SB795MHP73"
 
 [output.html]
 git-repository-url = "https://github.com/FuelLabs/fuel-docs"

--- a/book.toml
+++ b/book.toml
@@ -4,7 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "The Fuel Book"
-google_analytics_id: "G-SB795MHP73"
+google_analytics_id = "G-SB795MHP73"
 
 [output.html]
 git-repository-url = "https://github.com/FuelLabs/fuel-docs"


### PR DESCRIPTION
mdBook lets you track traffic on your generated website or docs simply by adding the tracking ID to the `book.toml` file.

This PR adds the Google Analytics tracking ID to `book.toml` for Fuel Book.