### PR TITLE
Update smart-contract guide instruction.

### DIFF
--- a/src/quickstart/smart-contract.md
+++ b/src/quickstart/smart-contract.md
@@ -80,7 +80,7 @@ counter-contract
 `Forc.toml` is the _manifest file_ (similar to `Cargo.toml` for Cargo or `package.json` for Node) and defines project metadata such as the project name and dependencies.
 <!-- forc_new:example:end -->
 
-Open your project in a code editor and delete the boilerplate code in `src/main.sw` so that you start with an empty file.
+Open your project in a code editor and delete everything in `src/main.sw` apart from the first line.
 
 Every Sway file must start with a declaration of what type of program the file contains; here, we've declared that this file is a contract.
 


### PR DESCRIPTION
This instruction: ”_Open your project in a code editor and delete the boilerplate code in src/main.sw so that you start with an empty file_.” was caussing the language server to crash with the following error:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', 
sway-parse/src/parser.rs:33:18
```

It seems that the parser in the compiler panics on an empty file which is causing the language server to crash. I tested this on master and the problem has since been resolved.

This PR updates the instruction to delete everything apart from the first line in order for the language server to not crash and be available for the rest of the tutorial. 