### PR TITLE
fix: Update version for fuels library

### DIFF
--- a/src/quickstart/frontend.md
+++ b/src/quickstart/frontend.md
@@ -46,7 +46,7 @@ Move into the `frontend` folder, then run:
 
 ```console
 $ cd frontend
-$ npm install fuels@0.38.0 @fuel-wallet/sdk --save
+$ npm install fuels@0.49.0 @fuel-wallet/sdk --save
 added 114 packages, and audited 115 packages in 9s
 ```
 


### PR DESCRIPTION
Just a small fix, when running through the tutorial ran into a error with the dependency versioning:

```
npm install fuels@0.38.0 @fuel-wallet/sdk --save
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: frontend@0.1.0
npm ERR! Found: fuels@0.38.0
npm ERR! node_modules/fuels
npm ERR!   fuels@"0.38.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer fuels@">=0.48.1" from @fuel-wallet/sdk@0.11.1
npm ERR! node_modules/@fuel-wallet/sdk
npm ERR!   @fuel-wallet/sdk@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Just updating the `fuels` package to the latest version fixes it.