### PR TITLE
Adding beta 4 networking section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,6 +37,7 @@
 - [For Developers](./for-developers/for-developer.md)
   - [Example Smart Contracts](./for-developers/example-contracts.md)
   - [Networks](./networks/networks.md)
+    - [Beta-4 Testnet](./networks/beta-4.md)
     - [Beta-3 Testnet](./networks/beta-3.md)
     - [Beta-2 Testnet](./networks/beta-2.md)
     - [Beta-1 Testnet](./networks/beta-1.md)

--- a/src/for-developers/faucet-and-blockexplorer.md
+++ b/src/for-developers/faucet-and-blockexplorer.md
@@ -1,11 +1,13 @@
 # Faucet and Block Explorer
 
-## Beta-3 Faucet
-
 <!-- This example should include a link to the latest testnet faucet-->
 <!-- faucet:example:start -->
-Assets for the beta-3 testnet can be obtained from the faucet at [https://faucet-beta-3.fuel.network/](https://faucet-beta-3.fuel.network/).
+Assets for the beta-4 testnet can be obtained from the faucet at [https://faucet-beta-4.fuel.network/](https://faucet-beta-4.fuel.network/).
 <!-- faucet:example:end -->
+
+## Beta-3 Faucet
+
+Assets for the beta-3 testnet can be obtained from the faucet at [https://faucet-beta-3.fuel.network/](https://faucet-beta-3.fuel.network/).
 
 ## Beta-2 Faucet
 

--- a/src/networks/beta-1.md
+++ b/src/networks/beta-1.md
@@ -14,7 +14,7 @@ Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to
 
 Version 0.17.0 is the recommended version of the TS SDK on `beta-1`.
 
-Version 0.30.0 is the recommended version for the Rusk SDK on `beta-1`,  
+Version 0.30.0 is the recommended version for the Rust SDK on `beta-1`,  
 
 ## Toolchain Configuration
 

--- a/src/networks/beta-2.md
+++ b/src/networks/beta-2.md
@@ -30,7 +30,7 @@ Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to
 
 Version 0.21.0 is the recommended version of the TS SDK on `beta-2`.  
 
-Version 0.30.0 is the recommended version for the Rusk SDK on `beta-2`.
+Version 0.30.0 is the recommended version for the Rust SDK on `beta-2`.
 
 ## Toolchain Configuration
 

--- a/src/networks/beta-3.md
+++ b/src/networks/beta-3.md
@@ -24,9 +24,9 @@ Join the [Fuel Labs Forum](https://forum.fuel.network/) to get support from our 
 
 ## SDK Versioning
 
-Version 0.38.0 or higher is the recommended version of the TS SDK on `beta-3`.  
+Version 0.38.0 up to 0.50.0 is the recommended version of the TS SDK on `beta-3`.  
 
-Version 0.39.0 or higher is the recommended version for the Rust SDK on `beta-3`.
+Version 0.39.0 up to 0.44.0 is the recommended version for the Rust SDK on `beta-3`.
 
 ## Toolchain Configuration
 

--- a/src/networks/beta-3.md
+++ b/src/networks/beta-3.md
@@ -44,12 +44,12 @@ fuelup toolchain install beta-3
 
 This installs the following components and versions:
 
-- forc 0.37.0
+- forc 0.37.3
 - forc-explore 0.28.1
-- forc-index 0.7.0
+- forc-index 0.15.0
 - forc-wallet 0.2.2
-- fuel-core 0.17.8
-- fuel-indexer 0.7.0
+- fuel-core 0.17.11
+- fuel-indexer 0.15.0
 
 To set the `beta-3` toolchain as your default, run
 

--- a/src/networks/beta-3.md
+++ b/src/networks/beta-3.md
@@ -1,6 +1,6 @@
 # The `beta-3` testnet
 
-The `beta-3` network is the latest Fuel testnet. It expands on the features of `beta-2`, introducing P2P networking and the ability to run synchronizing full nodes.
+The `beta-3` network is the third Fuel testnet. It expands on the features of `beta-2`, introducing P2P networking and the ability to run synchronizing full nodes.
 
 Ethereum contracts (Goerli):
 

--- a/src/networks/beta-3.md
+++ b/src/networks/beta-3.md
@@ -20,7 +20,7 @@ Goerli block explorer: [https://goerli.etherscan.io/](https://goerli.etherscan.i
 
 🔍 Block explorer - A block explorer (still heavily in development) is available at [https://fuellabs.github.io/block-explorer-v2/](https://fuellabs.github.io/block-explorer-v2/). Be sure to select `beta-3` from the dropdown on the top right.
 
-Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to the 🧪︱testnet channel to get support from our team.
+Join the [Fuel Labs Forum](https://forum.fuel.network/) to get support from our team and others building on Fuel!
 
 ## SDK Versioning
 

--- a/src/networks/beta-3.md
+++ b/src/networks/beta-3.md
@@ -26,7 +26,7 @@ Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to
 
 Version 0.38.0 or higher is the recommended version of the TS SDK on `beta-3`.  
 
-Version 0.39.0 or higher is the recommended version for the Rusk SDK on `beta-3`.
+Version 0.39.0 or higher is the recommended version for the Rust SDK on `beta-3`.
 
 ## Toolchain Configuration
 

--- a/src/networks/beta-4.md
+++ b/src/networks/beta-4.md
@@ -1,0 +1,66 @@
+# The `beta-4` testnet
+
+The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3``, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
+
+Ethereum contracts (Sepolia):
+
+"FuelMessagePortal": `0x457A5a9320d06118764c400163c441cb8551cfa2`
+
+"FuelChainState": `0x053cDdc8D065dEB051584a5ae4DB45348be285c9`
+
+"FuelERC20Gateway": `0x10530552f00079cfF07f3c6D541C651a667Cf41D`
+
+Sepolia block explorer: [https://sepolia.etherscan.io/](https://sepolia.etherscan.io)
+
+🚰 Faucet - Use the faucet to get test ETH to deploy contracts with or to interact with contracts. Available here: [https://faucet-beta-4.fuel.network/](https://faucet-beta-4.fuel.network/).
+
+📃 GraphQL endpoint - The Fuel Core node uses GraphQL instead of JSON RPC. A playground for the public GraphQL endpoint for beta-4 is available at [https://beta-4.fuel.network/playground](https://beta-4.fuel.network/playground).
+
+🔍 Block explorer - A block explorer (still heavily in development) is available at [https://fuellabs.github.io/block-explorer-v2/](https://fuellabs.github.io/block-explorer-v2/). Be sure to select `beta-4` from the dropdown on the top right.
+
+Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to the 🧪︱testnet channel to get support from our team.
+
+## SDK Versioning
+<!-- TODO: UPDATE VERSIONING HERE -->
+Version 0.38.0 or higher is the recommended version of the TS SDK on `beta-4`.  
+
+<!-- TODO: UPDATE VERSIONING HERE -->
+Version 0.39.0 or higher is the recommended version for the Rusk SDK on `beta-4`.
+
+## Toolchain Configuration
+
+To configure the optimal toolchain for `beta-4`, ensure you have [fuelup](https://fuellabs.github.io/fuelup/latest) installed, then run the following command:
+
+```shell
+fuelup self update
+```
+
+Then install the beta-4 toolchain with
+
+```shell
+fuelup toolchain install beta-4
+```
+
+This installs the following components and versions:
+
+<!-- TODO: UPDATE VERSIONING HERE -->
+- forc 0.37.0
+- forc-explore 0.28.1
+- forc-index 0.7.0
+- forc-wallet 0.2.2
+- fuel-core 0.17.8
+- fuel-indexer 0.7.0
+
+To set the `beta-4` toolchain as your default, run
+
+```console
+$ fuelup default beta-4
+default toolchain set to 'beta-4-aarch64-apple-darwin'
+```
+
+## Predicate
+
+Messages intended for contracts use a pre-defined predicate as the message recipient. This predicate allows anyone to relay the message to the target contract and only the target contract. Once the contract receives the message it can see who originated it along with any special message payload and processes it accordingly. Since anyone can relay the message using this predicate it opens up possibilities for automated message processing as a service.
+
+<!-- TODO: UPDATE PREDICATE ROOT HERE HERE -->
+The predicate root for the beta-4 testnet is `0x4df15e4a7c602404e353b7766db23a0d067960c201eb2d7a695a166548c4d80a`.

--- a/src/networks/beta-4.md
+++ b/src/networks/beta-4.md
@@ -21,6 +21,7 @@ Sepolia block explorer: [https://sepolia.etherscan.io/](https://sepolia.ethersca
 Join the [Fuel Labs Forum](https://forum.fuel.network/) to get support from our team and others building on Fuel!
 
 ## SDK Versioning
+
 Version 0.51.0 or higher is the recommended version of the TS SDK on `beta-4`.  
 
 Version 0.46.0 or higher is the recommended version for the Rust SDK on `beta-4`.

--- a/src/networks/beta-4.md
+++ b/src/networks/beta-4.md
@@ -21,11 +21,9 @@ Sepolia block explorer: [https://sepolia.etherscan.io/](https://sepolia.ethersca
 Join the [Fuel Labs Forum](https://forum.fuel.network/) to get support from our team and others building on Fuel!
 
 ## SDK Versioning
-<!-- TODO: UPDATE VERSIONING HERE -->
-Version 0.38.0 or higher is the recommended version of the TS SDK on `beta-4`.  
+Version 0.51.0 or higher is the recommended version of the TS SDK on `beta-4`.  
 
-<!-- TODO: UPDATE VERSIONING HERE -->
-Version 0.39.0 or higher is the recommended version for the Rust SDK on `beta-4`.
+Version 0.46.0 or higher is the recommended version for the Rust SDK on `beta-4`.
 
 ## Toolchain Configuration
 
@@ -43,13 +41,12 @@ fuelup toolchain install beta-4
 
 This installs the following components and versions:
 
-<!-- TODO: UPDATE VERSIONING HERE -->
-- forc 0.37.0
+- forc 0.44.0
 - forc-explore 0.28.1
-- forc-index 0.7.0
+- forc-index 0.19.5
 - forc-wallet 0.2.5
-- fuel-core 0.20.0
-- fuel-indexer 0.7.0
+- fuel-core 0.20.4
+- fuel-indexer 0.19.5
 
 To set the `beta-4` toolchain as your default, run
 
@@ -62,5 +59,4 @@ default toolchain set to 'beta-4-aarch64-apple-darwin'
 
 Messages intended for contracts use a pre-defined predicate as the message recipient. This predicate allows anyone to relay the message to the target contract and only the target contract. Once the contract receives the message it can see who originated it along with any special message payload and processes it accordingly. Since anyone can relay the message using this predicate it opens up possibilities for automated message processing as a service.
 
-<!-- TODO: UPDATE PREDICATE ROOT HERE HERE -->
-The predicate root for the beta-4 testnet is `0x4df15e4a7c602404e353b7766db23a0d067960c201eb2d7a695a166548c4d80a`.
+The predicate root for the beta-4 testnet is `0x86a8f7487cb0d3faca1895173d5ff35c1e839bd2ab88657eede9933ea8988815`.

--- a/src/networks/beta-4.md
+++ b/src/networks/beta-4.md
@@ -25,7 +25,7 @@ Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to
 Version 0.38.0 or higher is the recommended version of the TS SDK on `beta-4`.  
 
 <!-- TODO: UPDATE VERSIONING HERE -->
-Version 0.39.0 or higher is the recommended version for the Rusk SDK on `beta-4`.
+Version 0.39.0 or higher is the recommended version for the Rust SDK on `beta-4`.
 
 ## Toolchain Configuration
 

--- a/src/networks/beta-4.md
+++ b/src/networks/beta-4.md
@@ -1,6 +1,6 @@
 # The `beta-4` testnet
 
-The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3``, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
+The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3`, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
 
 Ethereum contracts (Sepolia):
 
@@ -18,7 +18,7 @@ Sepolia block explorer: [https://sepolia.etherscan.io/](https://sepolia.ethersca
 
 🔍 Block explorer - A block explorer (still heavily in development) is available at [https://fuellabs.github.io/block-explorer-v2/](https://fuellabs.github.io/block-explorer-v2/). Be sure to select `beta-4` from the dropdown on the top right.
 
-Join the [Fuel Labs Discord](https://discord.com/invite/fuelnetwork) and head to the 🧪︱testnet channel to get support from our team.
+Join the [Fuel Labs Forum](https://forum.fuel.network/) to get support from our team and others building on Fuel!
 
 ## SDK Versioning
 <!-- TODO: UPDATE VERSIONING HERE -->
@@ -47,8 +47,8 @@ This installs the following components and versions:
 - forc 0.37.0
 - forc-explore 0.28.1
 - forc-index 0.7.0
-- forc-wallet 0.2.2
-- fuel-core 0.17.8
+- forc-wallet 0.2.5
+- fuel-core 0.20.0
 - fuel-indexer 0.7.0
 
 To set the `beta-4` toolchain as your default, run

--- a/src/networks/networks.md
+++ b/src/networks/networks.md
@@ -5,7 +5,7 @@ On this page, you'll find information on the different testnet networks.
 ## `beta-4` testnet
 <!-- This example should include a description for the latest network -->
 <!-- latest_network:example:start -->
-The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3``, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
+The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3`, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
 
 Read more about `beta-4` [here.](./beta-4.md)
 <!-- latest_network:example:end -->

--- a/src/networks/networks.md
+++ b/src/networks/networks.md
@@ -2,12 +2,18 @@
 
 On this page, you'll find information on the different testnet networks.
 
-## `beta-3` testnet
-
+## `beta-4` testnet
 <!-- This example should include a description for the latest network -->
 <!-- latest_network:example:start -->
-The `beta-3` network is the latest Fuel testnet. It expands on the features of `beta-2`, introducing P2P networking and the ability to run synchronizing full nodes.
+The `beta-4` network is the latest Fuel testnet. It builds on the foundation of `beta-3``, enhancing public P2P access, allowing parallel predicate execution, and introducing a newly redesigned bridging approach that ensures security for full rollups.
+
+Read more about `beta-4` [here.](./beta-4.md)
 <!-- latest_network:example:end -->
+
+## `beta-3` testnet
+
+The `beta-3` network is the third Fuel testnet. It expands on the features of `beta-2`, introducing P2P networking and the ability to run synchronizing full nodes.
+
 Read more about `beta-3` [here.](./beta-3.md)
 
 ## `beta-2` testnet


### PR DESCRIPTION
Adding beta 4 as the latest version of the testnets.

TODO:
- [ ] Update versioning of each compatible component when available to the team