### PR TITLE
redirect to docs-hub

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,3 @@ git-repository-url = "https://github.com/FuelLabs/fuel-docs"
 
 [rust]
 edition = "2021"
-
-[output.html.redirect]
-"/developer-quickstart.html" = "https://fuelbook.fuel.network/master/quickstart/developer-quickstart.html"

--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=https://docs.fuel.network/">


### PR DESCRIPTION
This PR redirects all pages to the new docs-hub.